### PR TITLE
add `start-end` mode

### DIFF
--- a/ModeFactory.cpp
+++ b/ModeFactory.cpp
@@ -88,3 +88,10 @@ mode ModeFactory::doubles() {
 	r.function = ModeFunction::Doubles;
 	return r;
 }
+
+mode ModeFactory::startEnd(const char hex) {
+	mode r;
+	r.function = ModeFunction::StartEnd;
+    r.data1[0] = static_cast<cl_uchar>(hexValue(hex));
+	return r;
+}

--- a/ModeFactory.hpp
+++ b/ModeFactory.hpp
@@ -23,6 +23,7 @@ class ModeFactory {
 		static mode letters();
 		static mode numbers();
 		static mode doubles();
+	        static mode startEnd(const char charLeading);
 };
 
 #endif /* HPP_MODEFACTORY */

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ usage: ./ERADICATE2 [OPTIONS]
   Modes with arguments:
     --leading <single hex>  Score on hashes leading with given hex character.
     --matching <hex string> Score on hashes matching given hex string.
+    --start-end <hex>       Score on hashes start & end with given hex character.
 
   Advanced modes:
     --leading-range         Scores on hashes leading with characters within

--- a/eradicate2.cpp
+++ b/eradicate2.cpp
@@ -189,6 +189,7 @@ int main(int argc, char * * argv) {
 		bool bModeRange = false;
 		bool bModeMirror = false;
 		bool bModeDoubles = false;
+		std::string strModeStartEnd;
 		int rangeMin = 0;
 		int rangeMax = 0;
 		std::vector<size_t> vDeviceSkipIndex;
@@ -211,6 +212,7 @@ int main(int argc, char * * argv) {
 		argp.addSwitch('7', "range", bModeRange);
 		argp.addSwitch('8', "mirror", bModeMirror);
 		argp.addSwitch('9', "leading-doubles", bModeDoubles);
+		argp.addSwitch('z', "start-end", strModeStartEnd);
 		argp.addSwitch('m', "min", rangeMin);
 		argp.addSwitch('M', "max", rangeMax);
 		argp.addMultiSwitch('s', "skip", vDeviceSkipIndex);
@@ -270,6 +272,8 @@ int main(int argc, char * * argv) {
 			mode = ModeFactory::mirror();
 		} else if (bModeDoubles) {
 			mode = ModeFactory::doubles();
+		} else if (!strModeStartEnd.empty()) {
+			mode = ModeFactory::startEnd(strModeStartEnd.front());
 		} else {
 			std::cout << g_strHelp << std::endl;
 			return 0;

--- a/help.hpp
+++ b/help.hpp
@@ -28,6 +28,7 @@ usage: ./ERADICATE2 [OPTIONS]
   Modes with arguments:
     --leading <single hex>  Score on hashes leading with given hex character.
     --matching <hex string> Score on hashes matching given hex string.
+    --start-end <hex>       Score on hashes start & end with given hex character.
 
   Advanced modes:
     --leading-range         Scores on hashes leading with characters within

--- a/types.hpp
+++ b/types.hpp
@@ -11,7 +11,7 @@
 #endif
 
 enum class ModeFunction {
-	Benchmark, ZeroBytes, Matching, Leading, Range, Mirror, Doubles, LeadingRange
+	Benchmark, ZeroBytes, Matching, Leading, Range, Mirror, Doubles, LeadingRange, StartEnd
 };
 
 typedef struct {


### PR DESCRIPTION
## Pull request

The mode is going to add the possibility to create addresses that start and end with a giver hex character, such as `0x1111....1111`

## Changes
- I have created a new mode parsing the start-end flag, with one hex char as argument
- I have also modifed a bit the kernel code to add a new score function for the startend mode
- I have updated the readme with the new mode in the "Modes with argument" section