### PR TITLE
Fix errors with 2+ GPUs and simplify total speed calculation

### DIFF
--- a/Speed.cpp
+++ b/Speed.cpp
@@ -43,10 +43,6 @@ void Speed::update(const unsigned int numPoints, const unsigned int indexDevice)
 	}
 }
 
-double Speed::getSpeed() const {
-	return this->getSpeed(m_lSamples);
-}
-
 double Speed::getSpeed(const unsigned int indexDevice) const {
 	return m_mDeviceSamples.count(indexDevice) == 0 ? 0 : this->getSpeed(m_mDeviceSamples.at(indexDevice));
 }
@@ -69,7 +65,6 @@ void Speed::updateList(const unsigned int & numPoints, const long long & ns, sam
 	l.push_back(samplePair(ns, numPoints));
 
 	// Pop old samples until time difference between first and last element is less than or equal to m_sampleSeconds
-	// We don't need to check size of m_lSamples since it's always >= 1 at this point
 	while (l.size() > 2 && (l.back().first - l.front().first) / 1000000 > m_intervalSampleMs) {
 		l.pop_front();
 	}

--- a/Speed.cpp
+++ b/Speed.cpp
@@ -35,7 +35,6 @@ void Speed::update(const unsigned int numPoints, const unsigned int indexDevice)
 	const auto ns = std::chrono::steady_clock::now().time_since_epoch().count();
 	const bool bPrint = ((ns - m_lastPrint) / 1000000) > m_intervalPrintMs;
 
-	updateList(numPoints, ns, m_lSamples);
 	updateList(numPoints, ns, m_mDeviceSamples[indexDevice]);
 
 	if (bPrint) {
@@ -77,13 +76,15 @@ void Speed::updateList(const unsigned int & numPoints, const long long & ns, sam
 }
 
 void Speed::print() const {
-	const std::string strVT100ClearLine = "\33[2K\r";
-	std::cout << strVT100ClearLine << "Speed: " << formatSpeed(this->getSpeed());
-	
+	double totalSpeed = 0.0;
+	std::ostringstream oss;
 	// std::map is sorted by key so we'll always have the devices in numerical order
 	for (auto it = m_mDeviceSamples.begin(); it != m_mDeviceSamples.end(); ++it) {
-		std::cout << " GPU" << it->first << ": " << formatSpeed(this->getSpeed(it->second));
+		const double speed = this->getSpeed(it->second);
+		totalSpeed += speed;
+		oss << " GPU" << it->first << ": " << formatSpeed(speed);
 	}
 
-	std::cout << "\r" << std::flush;
+	const std::string strVT100ClearLine = "\33[2K\r";
+	std::cout << strVT100ClearLine << "Speed: " << formatSpeed(totalSpeed) << oss.str() << "\r" << std::flush;
 }

--- a/Speed.hpp
+++ b/Speed.hpp
@@ -18,7 +18,6 @@ public:
 	void update(const unsigned int numPoints, const unsigned int indexDevice);
 	void print() const;
 
-	double getSpeed() const;
 	double getSpeed(const unsigned int indexDevice) const;
 
 private:
@@ -31,7 +30,6 @@ private:
 
 	long long m_lastPrint;
 	mutable std::recursive_mutex m_mutex;
-	sampleList m_lSamples;
 	std::map<unsigned int, sampleList> m_mDeviceSamples;
 };
 


### PR DESCRIPTION
Fixed errors occurring when using 2 or more GPUs:
- Segmentation fault
- free(): invalid pointer
- double free or corruption (fasttop)
- Aborted (core dumped)

Removed unnecessary handling of samples for total speed. Now, the total speed is calculated as the sum of the speeds of individual GPUs, simplifying the code and improving stability.

Related to https://github.com/johguse/ERADICATE2/issues/6
